### PR TITLE
Build refund risk assessment plugin

### DIFF
--- a/refundguard-for-woocommerce/admin/dashboard.php
+++ b/refundguard-for-woocommerce/admin/dashboard.php
@@ -1,0 +1,52 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+add_action( 'wp_dashboard_setup', function() {
+    wp_add_dashboard_widget(
+        'refundguard_dashboard_widget',
+        __( 'RefundGuard Risk Overview', 'refundguard-for-woocommerce' ),
+        'refundguard_render_dashboard_widget'
+    );
+} );
+
+function refundguard_render_dashboard_widget() {
+    $today = date( 'Y-m-d' );
+    $args = [
+        'limit' => -1,
+        'status' => array_keys( wc_get_order_statuses() ),
+        'date_created' => $today,
+        'return' => 'ids',
+    ];
+    $orders_today = wc_get_orders( $args );
+    $high_risk_count = 0;
+    foreach ( $orders_today as $order_id ) {
+        $risk = refundguard_get_risk_score( $order_id );
+        if ( $risk['score'] === 'high' ) {
+            $high_risk_count++;
+        }
+    }
+    // Last 7 days average
+    $week_ago = date( 'Y-m-d', strtotime( '-6 days' ) );
+    $args7 = [
+        'limit' => -1,
+        'status' => array_keys( wc_get_order_statuses() ),
+        'date_created' => $week_ago . '...' . $today,
+        'return' => 'ids',
+    ];
+    $orders_7 = wc_get_orders( $args7 );
+    $total_score = 0;
+    $count = 0;
+    foreach ( $orders_7 as $order_id ) {
+        $risk = refundguard_get_risk_score( $order_id );
+        if ( $risk['score'] === 'high' ) $total_score += 3;
+        elseif ( $risk['score'] === 'medium' ) $total_score += 2;
+        else $total_score += 1;
+        $count++;
+    }
+    $avg = $count ? round( $total_score / $count, 2 ) : 0;
+    $avg_label = $avg >= 2.5 ? __( 'High', 'refundguard-for-woocommerce' ) : ( $avg >= 1.5 ? __( 'Medium', 'refundguard-for-woocommerce' ) : __( 'Low', 'refundguard-for-woocommerce' ) );
+    echo '<ul style="margin:0 0 1em 1em;">';
+    echo '<li><strong>' . __( 'Today\'s High-Risk Orders:', 'refundguard-for-woocommerce' ) . '</strong> ' . intval( $high_risk_count ) . '</li>';
+    echo '<li><strong>' . __( 'Avg. Risk Score (7 days):', 'refundguard-for-woocommerce' ) . '</strong> ' . esc_html( $avg_label ) . ' (' . esc_html( $avg ) . ')</li>';
+    echo '</ul>';
+}

--- a/refundguard-for-woocommerce/admin/settings-page.php
+++ b/refundguard-for-woocommerce/admin/settings-page.php
@@ -1,0 +1,47 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+function refundguard_render_settings_page() {
+    if ( ! current_user_can( 'manage_woocommerce' ) ) return;
+    $settings = get_option( 'refundguard_settings', [
+        'rule_category' => 1,
+        'rule_total' => 1,
+        'rule_country' => 1,
+        'rule_previous_orders' => 1,
+    ] );
+    if ( isset( $_POST['refundguard_save_settings'] ) && check_admin_referer( 'refundguard_save_settings' ) ) {
+        $settings['rule_category'] = ! empty( $_POST['rule_category'] ) ? 1 : 0;
+        $settings['rule_total'] = ! empty( $_POST['rule_total'] ) ? 1 : 0;
+        $settings['rule_country'] = ! empty( $_POST['rule_country'] ) ? 1 : 0;
+        $settings['rule_previous_orders'] = ! empty( $_POST['rule_previous_orders'] ) ? 1 : 0;
+        update_option( 'refundguard_settings', $settings );
+        echo '<div class="updated"><p>' . __( 'Settings saved.', 'refundguard-for-woocommerce' ) . '</p></div>';
+    }
+    ?>
+    <div class="wrap">
+        <h1><?php _e( 'RefundGuard Settings', 'refundguard-for-woocommerce' ); ?></h1>
+        <form method="post">
+            <?php wp_nonce_field( 'refundguard_save_settings' ); ?>
+            <table class="form-table">
+                <tr>
+                    <th><?php _e( 'Enable Product Category Rule', 'refundguard-for-woocommerce' ); ?></th>
+                    <td><input type="checkbox" name="rule_category" value="1" <?php checked( $settings['rule_category'], 1 ); ?> /></td>
+                </tr>
+                <tr>
+                    <th><?php _e( 'Enable Order Total Rule', 'refundguard-for-woocommerce' ); ?></th>
+                    <td><input type="checkbox" name="rule_total" value="1" <?php checked( $settings['rule_total'], 1 ); ?> /></td>
+                </tr>
+                <tr>
+                    <th><?php _e( 'Enable Shipping Country Rule', 'refundguard-for-woocommerce' ); ?></th>
+                    <td><input type="checkbox" name="rule_country" value="1" <?php checked( $settings['rule_country'], 1 ); ?> /></td>
+                </tr>
+                <tr>
+                    <th><?php _e( 'Enable Previous Orders Rule', 'refundguard-for-woocommerce' ); ?></th>
+                    <td><input type="checkbox" name="rule_previous_orders" value="1" <?php checked( $settings['rule_previous_orders'], 1 ); ?> /></td>
+                </tr>
+            </table>
+            <p><input type="submit" name="refundguard_save_settings" class="button-primary" value="<?php esc_attr_e( 'Save Settings', 'refundguard-for-woocommerce' ); ?>" /></p>
+        </form>
+    </div>
+    <?php
+}

--- a/refundguard-for-woocommerce/includes/order-hooks.php
+++ b/refundguard-for-woocommerce/includes/order-hooks.php
@@ -1,0 +1,25 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+// Add badge to admin order list
+add_filter( 'manage_edit-shop_order_columns', function( $columns ) {
+    $columns['refundguard_risk'] = __( 'Refund Risk', 'refundguard-for-woocommerce' );
+    return $columns;
+} );
+
+add_action( 'manage_shop_order_posts_custom_column', function( $column, $post_id ) {
+    if ( $column === 'refundguard_risk' ) {
+        $risk = refundguard_get_risk_score( $post_id );
+        $color = $risk['score'] === 'high' ? '#e74c3c' : ( $risk['score'] === 'medium' ? '#f39c12' : '#27ae60' );
+        $label = ucfirst( $risk['score'] );
+        echo '<span style="display:inline-block;padding:2px 8px;border-radius:12px;background:' . esc_attr( $color ) . ';color:#fff;font-weight:bold;">' . esc_html( $label ) . '</span>';
+    }
+}, 10, 2 );
+
+// Add badge to single order view (admin)
+add_action( 'woocommerce_admin_order_data_after_order_details', function( $order ) {
+    $risk = refundguard_get_risk_score( $order->get_id() );
+    $color = $risk['score'] === 'high' ? '#e74c3c' : ( $risk['score'] === 'medium' ? '#f39c12' : '#27ae60' );
+    $label = ucfirst( $risk['score'] );
+    echo '<p><strong>' . __( 'Refund Risk:', 'refundguard-for-woocommerce' ) . '</strong> <span style="display:inline-block;padding:2px 8px;border-radius:12px;background:' . esc_attr( $color ) . ';color:#fff;font-weight:bold;">' . esc_html( $label ) . '</span> <span style="color:#888;font-size:11px;">' . esc_html( $risk['reason'] ) . '</span></p>';
+} );

--- a/refundguard-for-woocommerce/includes/risk-score.php
+++ b/refundguard-for-woocommerce/includes/risk-score.php
@@ -1,0 +1,93 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+function refundguard_get_risk_score( $order_id ) {
+    $order = wc_get_order( $order_id );
+    if ( ! $order ) return [ 'score' => 'low', 'reason' => __( 'Order not found', 'refundguard-for-woocommerce' ) ];
+
+    $settings = get_option( 'refundguard_settings', [
+        'rule_category' => 1,
+        'rule_total' => 1,
+        'rule_country' => 1,
+        'rule_previous_orders' => 1,
+    ] );
+
+    $score = 0;
+    $reasons = [];
+
+    // Rule: Product Category
+    if ( ! empty( $settings['rule_category'] ) ) {
+        $categories = [];
+        foreach ( $order->get_items() as $item ) {
+            $product = $item->get_product();
+            if ( $product ) {
+                $terms = get_the_terms( $product->get_id(), 'product_cat' );
+                if ( $terms && ! is_wp_error( $terms ) ) {
+                    foreach ( $terms as $term ) {
+                        $categories[] = $term->slug;
+                    }
+                }
+            }
+        }
+        if ( in_array( 'high-risk', $categories ) ) {
+            $score += 2;
+            $reasons[] = __( 'High-risk product category', 'refundguard-for-woocommerce' );
+        }
+    }
+
+    // Rule: Order Total
+    if ( ! empty( $settings['rule_total'] ) ) {
+        $total = floatval( $order->get_total() );
+        if ( $total > 500 ) {
+            $score += 2;
+            $reasons[] = __( 'High order total', 'refundguard-for-woocommerce' );
+        } elseif ( $total > 200 ) {
+            $score += 1;
+            $reasons[] = __( 'Moderate order total', 'refundguard-for-woocommerce' );
+        }
+    }
+
+    // Rule: Shipping Country
+    if ( ! empty( $settings['rule_country'] ) ) {
+        $country = $order->get_shipping_country();
+        $high_risk_countries = [ 'NG', 'RU', 'UA', 'CN' ];
+        if ( in_array( $country, $high_risk_countries ) ) {
+            $score += 2;
+            $reasons[] = __( 'High-risk shipping country', 'refundguard-for-woocommerce' );
+        }
+    }
+
+    // Rule: Number of Previous Orders
+    if ( ! empty( $settings['rule_previous_orders'] ) ) {
+        $customer_id = $order->get_customer_id();
+        if ( $customer_id ) {
+            $customer_orders = wc_get_orders([
+                'customer_id' => $customer_id,
+                'exclude' => [ $order_id ],
+                'return' => 'ids',
+            ]);
+            $num_orders = count( $customer_orders );
+            if ( $num_orders < 2 ) {
+                $score += 2;
+                $reasons[] = __( 'New customer', 'refundguard-for-woocommerce' );
+            } elseif ( $num_orders < 5 ) {
+                $score += 1;
+                $reasons[] = __( 'Few previous orders', 'refundguard-for-woocommerce' );
+            }
+        }
+    }
+
+    // Score to label
+    if ( $score >= 4 ) {
+        $label = 'high';
+    } elseif ( $score >= 2 ) {
+        $label = 'medium';
+    } else {
+        $label = 'low';
+    }
+
+    return [
+        'score' => $label,
+        'reason' => implode( ', ', $reasons )
+    ];
+}

--- a/refundguard-for-woocommerce/pro/refundguard-pro.php
+++ b/refundguard-for-woocommerce/pro/refundguard-pro.php
@@ -1,0 +1,12 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+// Only load if WooCommerce is active
+if ( ! class_exists( 'WooCommerce' ) ) return;
+
+// Pro features loader
+// require_once __DIR__ . '/ai-scoring.php';
+// require_once __DIR__ . '/whatsapp-alert.php';
+// require_once __DIR__ . '/restock-importer.php';
+
+// TODO: Implement AI-powered risk scoring, auto-flag orders, advanced analytics, export, alerts, PO generation, CSV importer.

--- a/refundguard-for-woocommerce/refundguard-for-woocommerce.php
+++ b/refundguard-for-woocommerce/refundguard-for-woocommerce.php
@@ -1,0 +1,56 @@
+<?php
+/*
+Plugin Name: RefundGuard for WooCommerce
+Plugin URI: https://wordpress.org/plugins/refundguard-for-woocommerce/
+Description: RefundGuard for WooCommerce is a smart refund risk scanner that helps WooCommerce store owners detect and manage potentially risky orders. With refund score badges, analytics, and optional AI-powered tools, RefundGuard gives you peace of mind before shipping anything.
+Version: 1.0.0
+Author: RefundGuard Team
+Author URI: https://refundguard.com/
+License: GPL2
+Text Domain: refundguard-for-woocommerce
+Domain Path: /languages
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+define( 'REFUNDGUARD_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'REFUNDGUARD_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+define( 'REFUNDGUARD_PRO_PATH', REFUNDGUARD_PLUGIN_DIR . 'pro/refundguard-pro.php' );
+
+// Activation/Deactivation Hooks
+register_activation_hook( __FILE__, 'refundguard_activate' );
+register_deactivation_hook( __FILE__, 'refundguard_deactivate' );
+
+function refundguard_activate() {
+    // Activation logic here
+}
+
+function refundguard_deactivate() {
+    // Deactivation logic here
+}
+
+// Load Free or Pro
+if ( file_exists( REFUNDGUARD_PRO_PATH ) ) {
+    require_once REFUNDGUARD_PRO_PATH;
+} else {
+    require_once REFUNDGUARD_PLUGIN_DIR . 'includes/risk-score.php';
+    require_once REFUNDGUARD_PLUGIN_DIR . 'includes/order-hooks.php';
+    require_once REFUNDGUARD_PLUGIN_DIR . 'admin/dashboard.php';
+    require_once REFUNDGUARD_PLUGIN_DIR . 'admin/settings-page.php';
+}
+
+// Admin Menu Registration
+add_action( 'admin_menu', 'refundguard_admin_menu' );
+function refundguard_admin_menu() {
+    add_submenu_page(
+        'woocommerce',
+        __( 'RefundGuard', 'refundguard-for-woocommerce' ),
+        __( 'RefundGuard', 'refundguard-for-woocommerce' ),
+        'manage_woocommerce',
+        'refundguard-settings',
+        'refundguard_render_settings_page'
+    );
+}


### PR DESCRIPTION
Initial scaffolding and implementation of the free version of RefundGuard for WooCommerce, including rule-based risk scoring, order list badges, a dashboard widget, and a settings page.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc4cc714-480b-424d-aaad-1cc50c2f6b43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc4cc714-480b-424d-aaad-1cc50c2f6b43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

