### PR TITLE
Fix require_once paths: use admin/ and includes/ subdirectories as fi…

### DIFF
--- a/refundguard-for-woocommerce.php
+++ b/refundguard-for-woocommerce.php
@@ -36,10 +36,10 @@ function refundguard_deactivate() {
 if ( file_exists( REFUNDGUARD_PRO_PATH ) ) {
     require_once REFUNDGUARD_PRO_PATH;
 } else {
-    require_once REFUNDGUARD_PLUGIN_DIR . 'risk-score.php';
-    require_once REFUNDGUARD_PLUGIN_DIR . 'order-hooks.php';
-    require_once REFUNDGUARD_PLUGIN_DIR . 'dashboard.php';
-    require_once REFUNDGUARD_PLUGIN_DIR . 'settings-page.php';
+    require_once REFUNDGUARD_PLUGIN_DIR . 'includes/risk-score.php';
+    require_once REFUNDGUARD_PLUGIN_DIR . 'includes/order-hooks.php';
+    require_once REFUNDGUARD_PLUGIN_DIR . 'admin/dashboard.php';
+    require_once REFUNDGUARD_PLUGIN_DIR . 'admin/settings-page.php';
 }
 
 // Admin Menu Registration


### PR DESCRIPTION
The require_once paths in your main plugin file have been corrected to use the admin/ and includes/ subdirectories, matching your actual file structure.

Please pull the latest branch and try activating the plugin again. This should resolve the "function not found" fatal error.