### PR TITLE
Fix fatal error: always load free admin files so refundguard_render_s…

### DIFF
--- a/refundguard-for-woocommerce.php
+++ b/refundguard-for-woocommerce.php
@@ -32,14 +32,15 @@ function refundguard_deactivate() {
     // Deactivation logic here
 }
 
-// Load Free or Pro
+// Always load Free core/admin files
+require_once REFUNDGUARD_PLUGIN_DIR . 'includes/risk-score.php';
+require_once REFUNDGUARD_PLUGIN_DIR . 'includes/order-hooks.php';
+require_once REFUNDGUARD_PLUGIN_DIR . 'admin/dashboard.php';
+require_once REFUNDGUARD_PLUGIN_DIR . 'admin/settings-page.php';
+
+// Load Pro features if present
 if ( file_exists( REFUNDGUARD_PRO_PATH ) ) {
     require_once REFUNDGUARD_PRO_PATH;
-} else {
-    require_once REFUNDGUARD_PLUGIN_DIR . 'includes/risk-score.php';
-    require_once REFUNDGUARD_PLUGIN_DIR . 'includes/order-hooks.php';
-    require_once REFUNDGUARD_PLUGIN_DIR . 'admin/dashboard.php';
-    require_once REFUNDGUARD_PLUGIN_DIR . 'admin/settings-page.php';
 }
 
 // Admin Menu Registration


### PR DESCRIPTION
Summary

    The settings page function is not loaded when Pro is present, causing the fatal error.
    The fix is to always load the Free admin files, regardless of Pro.
    The Pro file should only add/override features, not replace the Free core.

