### PR TITLE
Add RefundGuard top-level menu, License tab, and Pro license check. P…

### DIFF
--- a/admin/license-page.php
+++ b/admin/license-page.php
@@ -1,0 +1,27 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+function refundguard_render_license_page() {
+    if ( ! current_user_can( 'manage_woocommerce' ) ) return;
+    if ( isset( $_POST['refundguard_save_license'] ) && check_admin_referer( 'refundguard_save_license' ) ) {
+        update_option( 'refundguard_pro_license', sanitize_text_field( $_POST['refundguard_pro_license'] ) );
+        echo '<div class="updated"><p>' . __( 'License saved.', 'refundguard-for-woocommerce' ) . '</p></div>';
+    }
+    $license = get_option( 'refundguard_pro_license', '' );
+    ?>
+    <div class="wrap">
+        <h1><?php _e( 'RefundGuard Pro License', 'refundguard-for-woocommerce' ); ?></h1>
+        <form method="post">
+            <?php wp_nonce_field( 'refundguard_save_license' ); ?>
+            <table class="form-table">
+                <tr>
+                    <th><?php _e( 'License Key', 'refundguard-for-woocommerce' ); ?></th>
+                    <td><input type="text" name="refundguard_pro_license" value="<?php echo esc_attr( $license ); ?>" size="40" /></td>
+                </tr>
+            </table>
+            <p><input type="submit" name="refundguard_save_license" class="button-primary" value="<?php esc_attr_e( 'Save License', 'refundguard-for-woocommerce' ); ?>" /></p>
+        </form>
+        <p><?php _e( 'Enter your RefundGuard Pro license key. Pro features will be enabled if a valid license is entered. (For testing, any value will enable Pro features.)', 'refundguard-for-woocommerce' ); ?></p>
+    </div>
+    <?php
+}

--- a/pro/refundguard-pro.php
+++ b/pro/refundguard-pro.php
@@ -4,7 +4,22 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 // Only load if WooCommerce is active
 if ( ! class_exists( 'WooCommerce' ) ) return;
 
-// Pro features loader
-
+// Only load Pro features if license is present
+add_action('admin_init', function() {
+    $license = get_option('refundguard_pro_license', '');
+    if (empty($license)) {
+        add_action('admin_notices', function() {
+            echo '<div class="notice notice-warning"><p>' . __( 'RefundGuard Pro is installed but not activated. Please enter your license key in RefundGuard > License.', 'refundguard-for-woocommerce' ) . '</p></div>';
+        });
+        return;
+    }
+    // Pro features loader (require other pro files here)
+    // require_once __DIR__ . '/ai-scoring.php';
+    // require_once __DIR__ . '/analytics.php';
+    // require_once __DIR__ . '/export.php';
+    // require_once __DIR__ . '/whatsapp-alert.php';
+    // require_once __DIR__ . '/po-generator.php';
+    // require_once __DIR__ . '/restock-importer.php';
+});
 
 // TODO: Implement AI-powered risk scoring, auto-flag orders, advanced analytics, export, alerts, PO generation, CSV importer.

--- a/refundguard-for-woocommerce.php
+++ b/refundguard-for-woocommerce.php
@@ -37,21 +37,48 @@ require_once REFUNDGUARD_PLUGIN_DIR . 'includes/risk-score.php';
 require_once REFUNDGUARD_PLUGIN_DIR . 'includes/order-hooks.php';
 require_once REFUNDGUARD_PLUGIN_DIR . 'admin/dashboard.php';
 require_once REFUNDGUARD_PLUGIN_DIR . 'admin/settings-page.php';
+require_once REFUNDGUARD_PLUGIN_DIR . 'admin/license-page.php';
 
 // Load Pro features if present
 if ( file_exists( REFUNDGUARD_PRO_PATH ) ) {
     require_once REFUNDGUARD_PRO_PATH;
 }
 
-// Admin Menu Registration
+// Admin Menu Registration (top-level RefundGuard menu)
 add_action( 'admin_menu', 'refundguard_admin_menu' );
 function refundguard_admin_menu() {
-    add_submenu_page(
-        'woocommerce',
+    add_menu_page(
         __( 'RefundGuard', 'refundguard-for-woocommerce' ),
         __( 'RefundGuard', 'refundguard-for-woocommerce' ),
         'manage_woocommerce',
-        'refundguard-settings',
+        'refundguard',
+        'refundguard_render_settings_page',
+        'dashicons-shield-alt',
+        56
+    );
+    add_submenu_page(
+        'refundguard',
+        __( 'Settings', 'refundguard-for-woocommerce' ),
+        __( 'Settings', 'refundguard-for-woocommerce' ),
+        'manage_woocommerce',
+        'refundguard',
         'refundguard_render_settings_page'
     );
+    add_submenu_page(
+        'refundguard',
+        __( 'Analytics', 'refundguard-for-woocommerce' ),
+        __( 'Analytics', 'refundguard-for-woocommerce' ),
+        'manage_woocommerce',
+        'refundguard-analytics',
+        'refundguard_render_analytics_page'
+    );
+    add_submenu_page(
+        'refundguard',
+        __( 'License', 'refundguard-for-woocommerce' ),
+        __( 'License', 'refundguard-for-woocommerce' ),
+        'manage_woocommerce',
+        'refundguard-license',
+        'refundguard_render_license_page'
+    );
+    // Add more Pro submenus as needed
 }


### PR DESCRIPTION
You will now see a dedicated RefundGuard top-level menu in your WordPress admin, with submenus for Settings, Analytics (Pro), and License.

    The License tab allows you to enter and save a license key (for now, any value will enable Pro features).
    Pro features will only load if a license key is present.
    If Pro is installed but not activated, an admin notice will prompt you to enter your license.
